### PR TITLE
FIX - read yaml comments in decrypt yaml

### DIFF
--- a/test/__snapshots__/core.spec.js.snap
+++ b/test/__snapshots__/core.spec.js.snap
@@ -1,5 +1,20 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`core decryptYAML with no-encrypt comments 1`] = `
+Array [
+  "public_key: value #no-encrypt
+secret: value2
+data2:
+  - name: name # no-encrypt
+    password: mypassword
+data:
+  - data1
+  - data2 # no-encrypt
+",
+  "ddezOk3Wwy95zJU0L9FSiQ==",
+]
+`;
+
 exports[`core encryptYAML with merge keys 1`] = `
 "source:
   &base

--- a/test/core.spec.js
+++ b/test/core.spec.js
@@ -68,6 +68,23 @@ describe('core', () => {
     const result = await core.encryptYAML(NODE_MASTER_KEY, yaml, "SlFF0O9iHgKpcds+/6nbEg==");
     expect(result).toMatchSnapshot();
   });
+
+  test('decryptYAML with no-encrypt comments', () => {
+    const yaml = `
+    public_key: value #no-encrypt
+    secret: nrAsTeEg9/vYwNLKeTSDcQ==--ddezOk3Wwy95zJU0L9FSiQ==
+    data2:
+      - name: name # no-encrypt
+        password: T0aRVXiI9dS2/KBQ8K4xug==--ddezOk3Wwy95zJU0L9FSiQ==
+    data:
+      - h4Iz7kBLKroCy9J4WdyhbA==--ddezOk3Wwy95zJU0L9FSiQ==
+      - data2 # no-encrypt
+    `;
+
+    const result = core.decryptYAML(NODE_MASTER_KEY, yaml);
+    expect(result).toMatchSnapshot();
+  });
+
   test('decrypt', async () => {
     const [result, iv] = await core.decrypt(
       NODE_MASTER_KEY,


### PR DESCRIPTION
When a yaml is encrypted and has some keys with the special comment `no-encrypt`, the decrypt functions throws an error and the yaml can't be decrypted.

Example:
```yaml
    public_key: value #no-encrypt
    secret: secret
    data2:
      - name: name # no-encrypt
        password: password
```

## How

Read comment when decrypting yaml and return the same value if have the special comment.